### PR TITLE
Add support for UTF-8 characters when calculating the signature

### DIFF
--- a/lib/signature.js
+++ b/lib/signature.js
@@ -22,7 +22,7 @@ _.extend(signature.prototype, {
     isValid: function(buffer){
         if(!this.secret) { throw new Error('No Secret Found'); }
         var hmac = crypto.createHmac(this.algorithm, this.secret);
-        hmac.update(buffer);
+        hmac.update(buffer, 'utf-8');
         var expected = this.algorithm + '=' + hmac.digest('hex');
         return this.xhub === expected;
     }

--- a/test/signature.js
+++ b/test/signature.js
@@ -64,4 +64,11 @@ describe('xhub.signature', function () {
         sig.isValid('random-signature-body').should.be.true;
     });
 
+    it('should return true when body contains UTF-8 chars and the signatures match', function(){
+        var xhub = 'sha1=6eca52592dced2ec4b9c974538d6bb32e25ab897';
+        var secret = 'my_little_secret';
+        var sig = new signature(xhub, { secret: secret });
+        sig.isValid('random-utf-8-あいうえお-body').should.be.true;
+    });
+
 });


### PR DESCRIPTION
The `crypto` module [defaults to using a `binary` encoding](https://nodejs.org/api/crypto.html#crypto_hash_update_data_input_encoding).  This doesn't play nice when using UTF-8 characters in the content the signature is being calculated for and results in an invalid signature.

By deliberately setting the hmac.update() encoding to 'utf-8' we resolve this issue.

I've added a test too.
