### PR TITLE
Allow overriding the secret at validation

### DIFF
--- a/lib/signature.js
+++ b/lib/signature.js
@@ -11,14 +11,15 @@ var Signature = function(xhub, options){
 
 Signature.prototype.attach = function(req, buffer){
     var isValid = this.isValid.bind(this);
-    req.isXHubValid = function(){
-        return isValid(buffer);
+    req.isXHubValid = function(secret){
+        return isValid(buffer, secret);
     };
 };
 
-Signature.prototype.isValid = function(buffer){
-    if(!this.secret) { throw new Error('No Secret Found'); }
-    var hmac = crypto.createHmac(this.algorithm, this.secret);
+Signature.prototype.isValid = function(buffer, secret){
+    secret = secret || this.secret;
+    if(!secret) { throw new Error('No Secret Found'); }
+    var hmac = crypto.createHmac(this.algorithm, secret);
     hmac.update(buffer, 'utf-8');
     var expected = this.algorithm + '=' + hmac.digest('hex');
     return this.xhub === expected;


### PR DESCRIPTION
When supporting multiple facebook apps you don't always know the secret at boot. This allows you to specify at validation time. 
